### PR TITLE
Improve relation labels

### DIFF
--- a/packages/strapi-plugin-content-manager/admin/src/components/RelationPreviewList/RelationPreviewTooltip.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/RelationPreviewList/RelationPreviewTooltip.js
@@ -52,7 +52,12 @@ const RelationPreviewTooltip = ({
 
   const getValueToDisplay = useCallback(
     item => {
-      return getDisplayedValue(mainField.schema.type, item[mainField.name], mainField.name);
+      const mainVal = getDisplayedValue(
+        mainField.schema.type,
+        item[mainField.name],
+        mainField.name
+      );
+      return mainField.name === 'id' ? `${item.id}` : `${item.id} - ${mainVal}`;
     },
     [mainField]
   );

--- a/packages/strapi-plugin-content-manager/admin/src/components/RelationPreviewList/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/RelationPreviewList/index.js
@@ -25,7 +25,11 @@ const RelationPreviewList = ({
   const [tooltipIsDisplayed, setDisplayTooltip] = useState(false);
   const isSingle = ['oneWay', 'oneToOne', 'manyToOne'].includes(relationType);
   const tooltipId = useMemo(() => `${rowId}-${cellId}`, [rowId, cellId]);
-  const valueToDisplay = value ? value[mainField.name] : '-';
+  const valueToDisplay = value
+    ? mainField.name === 'id'
+      ? `${value.id}`
+      : `${value.id} - ${value[mainField.name]}`
+    : '-';
 
   if (value === undefined) {
     return (

--- a/packages/strapi-plugin-content-manager/admin/src/components/SelectMany/Relation.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/SelectMany/Relation.js
@@ -44,7 +44,13 @@ const Relation = ({
     : formatMessage({ id: getTrad('containers.Edit.clickToJump') });
 
   const value = data[mainField.name];
-  const formattedValue = getDisplayedValue(mainField.schema.type, value, mainField.name);
+  const mainDisplay = getDisplayedValue(
+    mainField.schema.type,
+    value,
+    mainField.name
+  );
+  const formattedValue =
+    mainField.name === 'id' ? `${data.id}` : `${data.id} - ${mainDisplay}`;
 
   if (isDragging || !displayNavigationLink) {
     title = '';

--- a/packages/strapi-plugin-content-manager/admin/src/components/SelectOne/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/SelectOne/index.js
@@ -36,7 +36,17 @@ function SelectOne({
       onMenuScrollToBottom={onMenuScrollToBottom}
       placeholder={placeholder}
       styles={styles}
-      value={isNull(value) ? null : { label: get(value, [mainField.name], ''), value }}
+      value={
+        isNull(value)
+          ? null
+          : {
+              label:
+                mainField.name === 'id'
+                  ? `${value.id}`
+                  : `${value.id} - ${get(value, [mainField.name], '')}`,
+              value,
+            }
+      }
     />
   );
 }

--- a/packages/strapi-plugin-content-manager/admin/src/components/SelectWrapper/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/SelectWrapper/index.js
@@ -149,7 +149,12 @@ function SelectWrapper({
         });
 
         const formattedData = data.map(obj => {
-          return { value: obj, label: obj[mainField.name] };
+          const mainValue = obj[mainField.name];
+          const label =
+            mainField.name === 'id'
+              ? `${obj.id}`
+              : `${obj.id} - ${mainValue}`;
+          return { value: obj, label };
         });
 
         setOptions(prevState =>


### PR DESCRIPTION
## Summary
- show IDs when listing relation options or values in the admin panel
- keep selected field text after the id

## Testing
- `npm run lint` *(fails: npm-run-all not found)*