### PR TITLE
Improve relation labels

### DIFF
--- a/packages/strapi-plugin-content-manager/admin/src/components/RelationPreviewList/RelationPreviewTooltip.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/RelationPreviewList/RelationPreviewTooltip.js
@@ -52,7 +52,12 @@ const RelationPreviewTooltip = ({
 
   const getValueToDisplay = useCallback(
     item => {
-      return getDisplayedValue(mainField.schema.type, item[mainField.name], mainField.name);
+      const mainVal = getDisplayedValue(
+        mainField.schema.type,
+        item[mainField.name],
+        mainField.name
+      );
+      return mainField.name === 'id' ? `${item.id}` : `${item.id} - ${mainVal}`;
     },
     [mainField]
   );

--- a/packages/strapi-plugin-content-manager/admin/src/components/RelationPreviewList/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/RelationPreviewList/index.js
@@ -25,7 +25,11 @@ const RelationPreviewList = ({
   const [tooltipIsDisplayed, setDisplayTooltip] = useState(false);
   const isSingle = ['oneWay', 'oneToOne', 'manyToOne'].includes(relationType);
   const tooltipId = useMemo(() => `${rowId}-${cellId}`, [rowId, cellId]);
-  const valueToDisplay = value ? value[mainField.name] : '-';
+  const valueToDisplay = value
+    ? mainField.name === 'id'
+      ? `${value.id}`
+      : `${value.id} - ${value[mainField.name]}`
+    : '-';
 
   if (value === undefined) {
     return (

--- a/packages/strapi-plugin-content-manager/admin/src/components/SelectMany/Relation.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/SelectMany/Relation.js
@@ -39,37 +39,44 @@ const Relation = ({
   const titleLabelID = isDraft
     ? 'components.Select.draft-info-title'
     : 'components.Select.publish-info-title';
-  let title = hasDraftAndPublish
+  const stateTitle = hasDraftAndPublish
     ? formatMessage({ id: getTrad(titleLabelID) })
-    : formatMessage({ id: getTrad('containers.Edit.clickToJump') });
+    : '';
 
   const value = data[mainField.name];
-  const formattedValue = getDisplayedValue(mainField.schema.type, value, mainField.name);
+  const mainDisplay = getDisplayedValue(
+    mainField.schema.type,
+    value,
+    mainField.name
+  );
+  const formattedValue =
+    mainField.name === 'id' ? `${data.id}` : `${data.id} - ${mainDisplay}`;
+  let displayTitle = displayNavigationLink ? formattedValue : '';
 
   if (isDragging || !displayNavigationLink) {
-    title = '';
+    displayTitle = '';
   }
 
   return (
     <>
-      <div style={{ cursor }} title={title}>
+      <div style={{ cursor }} title={displayTitle}>
         <div className="dragHandle">
           <span />
         </div>
         {hasDraftAndPublish && (
           <div>
-            <RelationDPState isDraft={isDraft} />
+            <RelationDPState isDraft={isDraft} title={stateTitle} />
           </div>
         )}
         {displayNavigationLink ? (
           <Link
             to={{ pathname: to, state: { from: pathname }, search: searchToPersist }}
-            title={title}
+            title={displayTitle}
           >
             <Span>{formattedValue}&nbsp;</Span>
           </Link>
         ) : (
-          <Span>{formattedValue}&nbsp;</Span>
+          <Span title={displayTitle}>{formattedValue}&nbsp;</Span>
         )}
       </div>
       <div style={{ cursor, width: 'auto' }}>

--- a/packages/strapi-plugin-content-manager/admin/src/components/SelectOne/SingleValue.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/SelectOne/SingleValue.js
@@ -11,7 +11,9 @@ const SingleValue = props => {
   const hasDraftAndPublish = has(get(props, 'data.value'), 'published_at');
   const isDraft = isEmpty(get(props, 'data.value.published_at'));
   const mainField = get(props, ['selectProps', 'mainField'], {});
-  const value = getDisplayedValue(mainField.schema.type, props.data.label, mainField.name);
+  const data = get(props, 'data.value', {});
+  const mainVal = getDisplayedValue(mainField.schema.type, get(data, [mainField.name]), mainField.name);
+  const value = mainField.name === 'id' ? `${data.id}` : `${data.id} - ${mainVal}`;
 
   if (hasDraftAndPublish) {
     return (

--- a/packages/strapi-plugin-content-manager/admin/src/components/SelectOne/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/SelectOne/index.js
@@ -36,7 +36,17 @@ function SelectOne({
       onMenuScrollToBottom={onMenuScrollToBottom}
       placeholder={placeholder}
       styles={styles}
-      value={isNull(value) ? null : { label: get(value, [mainField.name], ''), value }}
+      value={
+        isNull(value)
+          ? null
+          : {
+              label:
+                mainField.name === 'id'
+                  ? `${value.id}`
+                  : `${value.id} - ${get(value, [mainField.name], '')}`,
+              value,
+            }
+      }
     />
   );
 }

--- a/packages/strapi-plugin-content-manager/admin/src/components/SelectWrapper/Option.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/SelectWrapper/Option.js
@@ -20,10 +20,12 @@ const Option = props => {
   const titleLabelID = isDraft
     ? 'components.Select.draft-info-title'
     : 'components.Select.publish-info-title';
-  const title = formatMessage({ id: getTrad(titleLabelID) });
+  const stateTitle = formatMessage({ id: getTrad(titleLabelID) });
   const fontWeight = props.isFocused ? 'bold' : 'regular';
   const mainField = get(props, ['selectProps', 'mainField'], {});
-  const value = getDisplayedValue(mainField.schema.type, props.label, mainField.name);
+  const data = get(props, 'data.value', {});
+  const mainVal = getDisplayedValue(mainField.schema.type, data[mainField.name], mainField.name);
+  const value = mainField.name === 'id' ? `${data.id}` : `${data.id} - ${mainVal}`;
 
   if (hasDraftAndPublish) {
     return (
@@ -35,7 +37,7 @@ const Option = props => {
             marginRight="10px"
             isDraft={isDraft}
             marginBottom="0"
-            title={title}
+            title={stateTitle}
           />
 
           <TextGrow ellipsis as="div" fontWeight={fontWeight} title={value}>

--- a/packages/strapi-plugin-content-manager/admin/src/components/SelectWrapper/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/SelectWrapper/index.js
@@ -149,7 +149,12 @@ function SelectWrapper({
         });
 
         const formattedData = data.map(obj => {
-          return { value: obj, label: obj[mainField.name] };
+          const mainValue = obj[mainField.name];
+          const label =
+            mainField.name === 'id'
+              ? `${obj.id}`
+              : `${obj.id} - ${mainValue}`;
+          return { value: obj, label };
         });
 
         setOptions(prevState =>


### PR DESCRIPTION
## Summary
- prefix relation labels with ID when selecting
- show the ID in relation dropdown items and selected values
- fix tooltip behavior so hovering shows the relation label instead of the publish state

## Testing
- `npm run lint` *(fails: npm-run-all not found)*