### PR TITLE
Improve relation labels

### DIFF
--- a/packages/strapi-plugin-content-manager/admin/src/components/RelationPreviewList/RelationPreviewTooltip.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/RelationPreviewList/RelationPreviewTooltip.js
@@ -9,6 +9,7 @@ const RelationPreviewTooltip = ({
   tooltipId,
   rowId,
   mainField,
+  displayFields,
   name,
   queryInfos: { endPoint },
   size,
@@ -52,9 +53,14 @@ const RelationPreviewTooltip = ({
 
   const getValueToDisplay = useCallback(
     item => {
-      return getDisplayedValue(mainField.schema.type, item[mainField.name], mainField.name);
+      const fields =
+        displayFields && displayFields.length ? displayFields : [mainField.name];
+      const vals = fields
+        .map(field => getDisplayedValue(mainField.schema.type, item[field], field))
+        .join(' ');
+      return `${item.id} - ${vals}`;
     },
-    [mainField]
+    [displayFields, mainField]
   );
 
   // Used to update the position after the loader
@@ -106,6 +112,7 @@ RelationPreviewTooltip.propTypes = {
       type: PropTypes.string.isRequired,
     }).isRequired,
   }).isRequired,
+  displayFields: PropTypes.arrayOf(PropTypes.string),
   name: PropTypes.string.isRequired,
   size: PropTypes.number.isRequired,
   rowId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,

--- a/packages/strapi-plugin-content-manager/admin/src/components/RelationPreviewList/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/RelationPreviewList/index.js
@@ -25,7 +25,15 @@ const RelationPreviewList = ({
   const [tooltipIsDisplayed, setDisplayTooltip] = useState(false);
   const isSingle = ['oneWay', 'oneToOne', 'manyToOne'].includes(relationType);
   const tooltipId = useMemo(() => `${rowId}-${cellId}`, [rowId, cellId]);
-  const valueToDisplay = value ? value[mainField.name] : '-';
+  const fields =
+    metadatas.displayFields && metadatas.displayFields.length
+      ? metadatas.displayFields
+      : [mainField.name];
+  const label =
+    value && value.id != null
+      ? `${value.id} - ${fields.map(field => value[field]).join(' ')}`
+      : '-';
+  const valueToDisplay = label;
 
   if (value === undefined) {
     return (
@@ -83,6 +91,7 @@ const RelationPreviewList = ({
           tooltipId={tooltipId}
           value={value}
           mainField={mainField}
+          displayFields={metadatas.displayFields}
           queryInfos={queryInfos}
           size={size}
         />
@@ -96,6 +105,7 @@ RelationPreviewList.propTypes = {
     cellId: PropTypes.string.isRequired,
     metadatas: PropTypes.shape({
       mainField: PropTypes.object.isRequired,
+      displayFields: PropTypes.arrayOf(PropTypes.string),
     }).isRequired,
     name: PropTypes.string.isRequired,
     relationType: PropTypes.string,

--- a/packages/strapi-plugin-content-manager/admin/src/components/SelectMany/Relation.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/SelectMany/Relation.js
@@ -18,6 +18,7 @@ const Relation = ({
   isDisabled,
   isDragging,
   mainField,
+  displayFields,
   onRemove,
   searchToPersist,
   to,
@@ -43,8 +44,12 @@ const Relation = ({
     ? formatMessage({ id: getTrad(titleLabelID) })
     : formatMessage({ id: getTrad('containers.Edit.clickToJump') });
 
-  const value = data[mainField.name];
-  const formattedValue = getDisplayedValue(mainField.schema.type, value, mainField.name);
+  const fields = (displayFields && displayFields.length)
+    ? displayFields
+    : [mainField.name];
+  const formattedValue = `${data.id} - ${fields
+    .map(field => getDisplayedValue(mainField.schema.type, data[field], field))
+    .join(' ')}`;
 
   if (isDragging || !displayNavigationLink) {
     title = '';
@@ -84,6 +89,7 @@ Relation.defaultProps = {
   onRemove: () => {},
   searchToPersist: null,
   to: '',
+  displayFields: null,
 };
 
 Relation.propTypes = {
@@ -98,6 +104,7 @@ Relation.propTypes = {
       type: PropTypes.string.isRequired,
     }).isRequired,
   }).isRequired,
+  displayFields: PropTypes.arrayOf(PropTypes.string),
   onRemove: PropTypes.func,
   searchToPersist: PropTypes.string,
   to: PropTypes.string,

--- a/packages/strapi-plugin-content-manager/admin/src/components/SelectOne/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/SelectOne/index.js
@@ -7,6 +7,7 @@ import SingleValue from './SingleValue';
 function SelectOne({
   components,
   mainField,
+  displayFields,
   name,
   isDisabled,
   isLoading,
@@ -36,7 +37,18 @@ function SelectOne({
       onMenuScrollToBottom={onMenuScrollToBottom}
       placeholder={placeholder}
       styles={styles}
-      value={isNull(value) ? null : { label: get(value, [mainField.name], ''), value }}
+      value={
+        isNull(value)
+          ? null
+          : {
+              label: `${value.id} - ${(
+                (displayFields && displayFields.length) ? displayFields : [mainField.name]
+              )
+                .map(field => get(value, [field], ''))
+                .join(' ')}`,
+              value,
+            }
+      }
     />
   );
 }
@@ -44,6 +56,7 @@ function SelectOne({
 SelectOne.defaultProps = {
   components: {},
   value: null,
+  displayFields: null,
 };
 
 SelectOne.propTypes = {
@@ -56,6 +69,7 @@ SelectOne.propTypes = {
       type: PropTypes.string.isRequired,
     }).isRequired,
   }).isRequired,
+  displayFields: PropTypes.arrayOf(PropTypes.string),
   name: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
   onInputChange: PropTypes.func.isRequired,

--- a/packages/strapi-plugin-content-manager/admin/src/components/SelectWrapper/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/SelectWrapper/index.js
@@ -52,6 +52,7 @@ function SelectWrapper({
   isFieldAllowed,
   isFieldReadable,
   mainField,
+  displayFields,
   name,
   relationType,
   targetModel,
@@ -149,7 +150,12 @@ function SelectWrapper({
         });
 
         const formattedData = data.map(obj => {
-          return { value: obj, label: obj[mainField.name] };
+          const fields = (displayFields && displayFields.length)
+            ? displayFields
+            : [mainField.name];
+          const values = fields.map(f => obj[f]).join(' ');
+          const label = `${obj.id} - ${values}`;
+          return { value: obj, label };
         });
 
         setOptions(prevState =>
@@ -178,6 +184,7 @@ function SelectWrapper({
       endPoint,
       idsToOmit,
       mainField.name,
+      displayFields,
     ]
   );
 
@@ -319,6 +326,7 @@ function SelectWrapper({
           isLoading={isLoading}
           isClearable
           mainField={mainField}
+          displayFields={displayFields}
           move={moveRelation}
           name={name}
           options={filteredOptions}
@@ -353,6 +361,7 @@ SelectWrapper.defaultProps = {
   labelIcon: null,
   isFieldAllowed: true,
   placeholder: '',
+  displayFields: null,
 };
 
 SelectWrapper.propTypes = {
@@ -375,6 +384,7 @@ SelectWrapper.propTypes = {
       type: PropTypes.string.isRequired,
     }).isRequired,
   }).isRequired,
+  displayFields: PropTypes.arrayOf(PropTypes.string),
   name: PropTypes.string.isRequired,
   placeholder: PropTypes.string,
   relationType: PropTypes.string.isRequired,

--- a/packages/strapi-plugin-content-manager/admin/src/hooks/useFetchContentTypeLayout/utils/formatLayouts.js
+++ b/packages/strapi-plugin-content-manager/admin/src/hooks/useFetchContentTypeLayout/utils/formatLayouts.js
@@ -71,7 +71,8 @@ const createMetasSchema = (initialData, models) => {
 
       if (schema.type === 'relation') {
         const relationModel = getRelationModel(schema.targetModel, models);
-        const mainFieldName = metadatas.edit.mainField;
+        const mainFieldNames = [].concat(metadatas.edit.mainField || 'id');
+        const mainFieldName = mainFieldNames[0];
         const mainField = {
           name: mainFieldName,
           schema: get(relationModel, ['attributes', mainFieldName]),
@@ -81,10 +82,12 @@ const createMetasSchema = (initialData, models) => {
           list: {
             ...metadatas.list,
             mainField,
+            displayFields: mainFieldNames,
           },
           edit: {
             ...metadatas.edit,
             mainField,
+            displayFields: mainFieldNames,
           },
         };
       }

--- a/packages/strapi-plugin-content-manager/admin/src/utils/formatLayoutToApi.js
+++ b/packages/strapi-plugin-content-manager/admin/src/utils/formatLayoutToApi.js
@@ -14,9 +14,12 @@ const formatLayoutToApi = ({ layouts, metadatas, ...rest }) => {
     const currentMetadatas = get(metadatas, [current], {});
     let editMetadatas = currentMetadatas.edit;
 
-    if (editMetadatas.mainField) {
-      editMetadatas = { ...editMetadatas, mainField: currentMetadatas.edit.mainField.name };
+    if (Array.isArray(editMetadatas.displayFields)) {
+      editMetadatas = { ...editMetadatas, mainField: editMetadatas.displayFields };
+    } else if (editMetadatas.mainField && editMetadatas.mainField.name) {
+      editMetadatas = { ...editMetadatas, mainField: editMetadatas.mainField.name };
     }
+    editMetadatas = omit(editMetadatas, ['displayFields']);
 
     return {
       ...acc,

--- a/packages/strapi-plugin-content-manager/controllers/collection-types.js
+++ b/packages/strapi-plugin-content-manager/controllers/collection-types.js
@@ -273,10 +273,11 @@ module.exports = {
 
     const config = await contentTypeService.findConfiguration({ uid: model });
     const mainField = prop(['metadatas', assoc.alias, 'edit', 'mainField'], config);
+    const fields = Array.isArray(mainField) ? mainField : [mainField];
 
     ctx.body = {
       pagination: relationList.pagination,
-      results: relationList.results.map(pick(['id', modelDef.primaryKey, mainField])),
+      results: relationList.results.map(pick(['id', modelDef.primaryKey, ...fields])),
     };
   },
 };

--- a/packages/strapi-plugin-content-manager/controllers/relations.js
+++ b/packages/strapi-plugin-content-manager/controllers/relations.js
@@ -55,8 +55,12 @@ module.exports = {
       ? await getService('components').findConfiguration(modelDef)
       : await getService('content-types').findConfiguration(modelDef);
 
-    const field = prop(`metadatas.${targetField}.edit.mainField`, modelConfig) || 'id';
-    const pickFields = [field, 'id', target.primaryKey, PUBLISHED_AT_ATTRIBUTE];
+    const field = prop(
+      `metadatas.${targetField}.edit.mainField`,
+      modelConfig
+    ) || 'id';
+    const fields = Array.isArray(field) ? field : [field];
+    const pickFields = fields.concat(['id', target.primaryKey, PUBLISHED_AT_ATTRIBUTE]);
 
     ctx.body = entities.map(pick(pickFields));
   },

--- a/packages/strapi-plugin-content-manager/controllers/validation/model-configuration.js
+++ b/packages/strapi-plugin-content-manager/controllers/validation/model-configuration.js
@@ -42,8 +42,15 @@ const createSettingsSchema = schema => {
       searchable: yup.boolean().required(),
       // should be reset when the type changes
       mainField: yup
-        .string()
-        .oneOf(validAttributes.concat('id'))
+        .mixed()
+        .test('is-valid', '${path} must be a string or array', value => {
+          if (Array.isArray(value)) {
+            return value.every(v => validAttributes.concat('id').includes(v));
+          }
+          return typeof value === 'string'
+            ? validAttributes.concat('id').includes(value)
+            : false;
+        })
         .default('id'),
       // should be reset when the type changes
       defaultSortBy: yup
@@ -72,7 +79,18 @@ const createMetadasSchema = schema => {
               placeholder: yup.string(),
               editable: yup.boolean(),
               visible: yup.boolean(),
-              mainField: yup.string(),
+              mainField: yup.mixed().test(
+                'is-valid',
+                '${path} must be a string or array',
+                value => {
+                  if (Array.isArray(value)) {
+                    return value.every(v => Object.keys(schema.attributes).includes(v));
+                  }
+                  return typeof value === 'string'
+                    ? Object.keys(schema.attributes).includes(value) || value === 'id'
+                    : false;
+                }
+              ),
             })
             .noUnknown()
             .required(),

--- a/packages/strapi-plugin-content-manager/services/utils/configuration/metadatas.js
+++ b/packages/strapi-plugin-content-manager/services/utils/configuration/metadatas.js
@@ -112,15 +112,17 @@ async function syncMetadatas(configuration, schema) {
       return acc;
     }
 
-    // if the mainField is id you can keep it
-    if (edit.mainField === 'id') return acc;
+    const mainFields = Array.isArray(edit.mainField) ? edit.mainField : [edit.mainField];
 
-    // check the mainField in the targetModel
+    if (mainFields.length === 1 && mainFields[0] === 'id') return acc;
+
     const targetSchema = getTargetSchema(attr.targetModel);
 
     if (!targetSchema) return acc;
 
-    if (!isSortable(targetSchema, edit.mainField)) {
+    const isValid = mainFields.every(field => isSortable(targetSchema, field));
+
+    if (!isValid) {
       _.set(updatedMeta, ['edit', 'mainField'], getDefaultMainField(targetSchema));
       _.set(acc, [key], updatedMeta);
       return acc;


### PR DESCRIPTION
## Summary
- show IDs when listing relation options or values in the admin panel
- keep selected field text after the id
- allow multiple display fields per relation

## Testing
- `npm run lint` *(fails: npm-run-all not found)*