### PR TITLE
Improve relation labels

### DIFF
--- a/packages/strapi-plugin-content-manager/admin/src/components/MultiSelect/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/MultiSelect/index.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Select from 'react-select';
+
+function MultiSelect({ name, value, options, onChange, isDisabled, isLoading, placeholder }) {
+  const formattedOptions = options.map(opt => ({ label: opt, value: opt }));
+  const formattedValue = (value || []).map(val => ({ label: val, value: val }));
+
+  return (
+    <Select
+      inputId={name}
+      isMulti
+      isDisabled={isDisabled}
+      isLoading={isLoading}
+      options={formattedOptions}
+      value={formattedValue}
+      onChange={vals => onChange({ target: { name, value: vals.map(v => v.value) } })}
+      placeholder={placeholder}
+    />
+  );
+}
+
+MultiSelect.defaultProps = {
+  value: [],
+  isDisabled: false,
+  isLoading: false,
+  placeholder: '',
+};
+
+MultiSelect.propTypes = {
+  name: PropTypes.string.isRequired,
+  value: PropTypes.array,
+  options: PropTypes.array.isRequired,
+  onChange: PropTypes.func.isRequired,
+  isDisabled: PropTypes.bool,
+  isLoading: PropTypes.bool,
+  placeholder: PropTypes.node,
+};
+
+export default MultiSelect;

--- a/packages/strapi-plugin-content-manager/admin/src/components/RelationPreviewList/RelationPreviewTooltip.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/RelationPreviewList/RelationPreviewTooltip.js
@@ -3,12 +3,12 @@ import { Text, Padded } from '@buffetjs/core';
 import { request } from 'strapi-helper-plugin';
 import { LoadingIndicator, Tooltip } from '@buffetjs/styles';
 import PropTypes from 'prop-types';
-import { getDisplayedValue, getRequestUrl } from '../../utils';
+import { getRequestUrl } from '../../utils';
 
 const RelationPreviewTooltip = ({
   tooltipId,
   rowId,
-  mainField,
+  displayFields,
   name,
   queryInfos: { endPoint },
   size,
@@ -51,10 +51,8 @@ const RelationPreviewTooltip = ({
   }, [fetchRelationData]);
 
   const getValueToDisplay = useCallback(
-    item => {
-      return getDisplayedValue(mainField.schema.type, item[mainField.name], mainField.name);
-    },
-    [mainField]
+    item => `${item.id} - ${displayFields.map(field => item[field]).join(' ')}`,
+    [displayFields]
   );
 
   // Used to update the position after the loader
@@ -100,12 +98,7 @@ const RelationPreviewTooltip = ({
 
 RelationPreviewTooltip.propTypes = {
   tooltipId: PropTypes.string.isRequired,
-  mainField: PropTypes.exact({
-    name: PropTypes.string.isRequired,
-    schema: PropTypes.shape({
-      type: PropTypes.string.isRequired,
-    }).isRequired,
-  }).isRequired,
+  displayFields: PropTypes.array.isRequired,
   name: PropTypes.string.isRequired,
   size: PropTypes.number.isRequired,
   rowId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,

--- a/packages/strapi-plugin-content-manager/admin/src/components/RelationPreviewList/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/RelationPreviewList/index.js
@@ -12,7 +12,7 @@ import RelationPreviewTooltip from './RelationPreviewTooltip';
 
 const RelationPreviewList = ({
   options: {
-    metadatas: { mainField },
+    metadatas: { displayFields },
     relationType,
     value,
     rowId,
@@ -25,7 +25,9 @@ const RelationPreviewList = ({
   const [tooltipIsDisplayed, setDisplayTooltip] = useState(false);
   const isSingle = ['oneWay', 'oneToOne', 'manyToOne'].includes(relationType);
   const tooltipId = useMemo(() => `${rowId}-${cellId}`, [rowId, cellId]);
-  const valueToDisplay = value ? value[mainField.name] : '-';
+  const valueToDisplay = value
+    ? `${value.id} - ${displayFields.map(field => value[field]).join(' ')}`
+    : '-';
 
   if (value === undefined) {
     return (
@@ -82,7 +84,7 @@ const RelationPreviewList = ({
           rowId={rowId}
           tooltipId={tooltipId}
           value={value}
-          mainField={mainField}
+          displayFields={displayFields}
           queryInfos={queryInfos}
           size={size}
         />
@@ -95,7 +97,7 @@ RelationPreviewList.propTypes = {
   options: PropTypes.shape({
     cellId: PropTypes.string.isRequired,
     metadatas: PropTypes.shape({
-      mainField: PropTypes.object.isRequired,
+      displayFields: PropTypes.array.isRequired,
     }).isRequired,
     name: PropTypes.string.isRequired,
     relationType: PropTypes.string,

--- a/packages/strapi-plugin-content-manager/admin/src/components/SelectMany/ListItem.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/SelectMany/ListItem.js
@@ -15,7 +15,7 @@ function ListItem({
   displayNavigationLink,
   findRelation,
   isDisabled,
-  mainField,
+  displayFields,
   moveRelation,
   onRemove,
   searchToPersist,
@@ -33,7 +33,7 @@ function ListItem({
       originalIndex,
       data,
       hasDraftAndPublish,
-      mainField,
+      displayFields,
     },
     collect: monitor => ({
       isDragging: monitor.isDragging(),
@@ -68,7 +68,7 @@ function ListItem({
       <Relation
         displayNavigationLink={displayNavigationLink}
         hasDraftAndPublish={hasDraftAndPublish}
-        mainField={mainField}
+        displayFields={displayFields}
         onRemove={onRemove}
         data={data}
         to={to}
@@ -92,12 +92,7 @@ ListItem.propTypes = {
   displayNavigationLink: PropTypes.bool.isRequired,
   findRelation: PropTypes.func,
   isDisabled: PropTypes.bool.isRequired,
-  mainField: PropTypes.shape({
-    name: PropTypes.string.isRequired,
-    schema: PropTypes.shape({
-      type: PropTypes.string.isRequired,
-    }).isRequired,
-  }).isRequired,
+  displayFields: PropTypes.array.isRequired,
   moveRelation: PropTypes.func,
   onRemove: PropTypes.func,
   searchToPersist: PropTypes.string,

--- a/packages/strapi-plugin-content-manager/admin/src/components/SelectMany/Relation.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/SelectMany/Relation.js
@@ -5,7 +5,7 @@ import { Link, useLocation } from 'react-router-dom';
 import { isEmpty } from 'lodash';
 import { useIntl } from 'react-intl';
 import { RelationDPState } from 'strapi-helper-plugin';
-import { getDisplayedValue, getTrad } from '../../utils';
+import { getTrad } from '../../utils';
 import IconRemove from '../../assets/images/icon_remove.svg';
 import { Span } from './components';
 
@@ -17,7 +17,7 @@ const Relation = ({
   hasDraftAndPublish,
   isDisabled,
   isDragging,
-  mainField,
+  displayFields,
   onRemove,
   searchToPersist,
   to,
@@ -43,8 +43,8 @@ const Relation = ({
     ? formatMessage({ id: getTrad(titleLabelID) })
     : formatMessage({ id: getTrad('containers.Edit.clickToJump') });
 
-  const value = data[mainField.name];
-  const formattedValue = getDisplayedValue(mainField.schema.type, value, mainField.name);
+  const mainDisplay = displayFields.map(field => data[field]).join(' ');
+  const formattedValue = `${data.id} - ${mainDisplay}`;
 
   if (isDragging || !displayNavigationLink) {
     title = '';
@@ -92,12 +92,7 @@ Relation.propTypes = {
   hasDraftAndPublish: PropTypes.bool.isRequired,
   isDisabled: PropTypes.bool.isRequired,
   isDragging: PropTypes.bool,
-  mainField: PropTypes.shape({
-    name: PropTypes.string.isRequired,
-    schema: PropTypes.shape({
-      type: PropTypes.string.isRequired,
-    }).isRequired,
-  }).isRequired,
+  displayFields: PropTypes.array.isRequired,
   onRemove: PropTypes.func,
   searchToPersist: PropTypes.string,
   to: PropTypes.string,

--- a/packages/strapi-plugin-content-manager/admin/src/components/SelectMany/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/SelectMany/index.js
@@ -11,7 +11,7 @@ function SelectMany({
   addRelation,
   components,
   displayNavigationLink,
-  mainField,
+  displayFields,
   name,
   isDisabled,
   isLoading,
@@ -78,7 +78,7 @@ function SelectMany({
 
           return true;
         }}
-        mainField={mainField}
+        displayFields={displayFields}
         isLoading={isLoading}
         isMulti
         isSearchable
@@ -103,7 +103,7 @@ function SelectMany({
                 displayNavigationLink={displayNavigationLink}
                 isDisabled={isDisabled}
                 findRelation={findRelation}
-                mainField={mainField}
+                displayFields={displayFields}
                 moveRelation={moveRelation}
                 onRemove={() => {
                   if (!isDisabled) {
@@ -135,12 +135,7 @@ SelectMany.propTypes = {
   displayNavigationLink: PropTypes.bool.isRequired,
   isDisabled: PropTypes.bool.isRequired,
   isLoading: PropTypes.bool.isRequired,
-  mainField: PropTypes.shape({
-    name: PropTypes.string.isRequired,
-    schema: PropTypes.shape({
-      type: PropTypes.string.isRequired,
-    }).isRequired,
-  }).isRequired,
+  displayFields: PropTypes.array.isRequired,
   move: PropTypes.func,
   name: PropTypes.string.isRequired,
   onInputChange: PropTypes.func.isRequired,

--- a/packages/strapi-plugin-content-manager/admin/src/components/SelectOne/SingleValue.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/SelectOne/SingleValue.js
@@ -4,14 +4,12 @@ import PropTypes from 'prop-types';
 import { get, has, isEmpty } from 'lodash';
 import { Flex, Padded, Text } from '@buffetjs/core';
 import { RelationDPState } from 'strapi-helper-plugin';
-import { getDisplayedValue } from '../../utils';
 
 const SingleValue = props => {
   const Component = components.SingleValue;
   const hasDraftAndPublish = has(get(props, 'data.value'), 'published_at');
   const isDraft = isEmpty(get(props, 'data.value.published_at'));
-  const mainField = get(props, ['selectProps', 'mainField'], {});
-  const value = getDisplayedValue(mainField.schema.type, props.data.label, mainField.name);
+  const value = props.data.label;
 
   if (hasDraftAndPublish) {
     return (
@@ -45,14 +43,7 @@ const SingleValue = props => {
 
 SingleValue.propTypes = {
   data: PropTypes.object.isRequired,
-  selectProps: PropTypes.shape({
-    mainField: PropTypes.shape({
-      name: PropTypes.string.isRequired,
-      schema: PropTypes.shape({
-        type: PropTypes.string.isRequired,
-      }).isRequired,
-    }).isRequired,
-  }).isRequired,
+  selectProps: PropTypes.object.isRequired,
 };
 
 export default SingleValue;

--- a/packages/strapi-plugin-content-manager/admin/src/components/SelectOne/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/SelectOne/index.js
@@ -6,7 +6,7 @@ import SingleValue from './SingleValue';
 
 function SelectOne({
   components,
-  mainField,
+  displayFields,
   name,
   isDisabled,
   isLoading,
@@ -27,7 +27,7 @@ function SelectOne({
       isClearable
       isDisabled={isDisabled}
       isLoading={isLoading}
-      mainField={mainField}
+      mainField={{ name: displayFields[0] }}
       options={options}
       onChange={onChange}
       onInputChange={onInputChange}
@@ -36,7 +36,11 @@ function SelectOne({
       onMenuScrollToBottom={onMenuScrollToBottom}
       placeholder={placeholder}
       styles={styles}
-      value={isNull(value) ? null : { label: get(value, [mainField.name], ''), value }}
+      value={
+        isNull(value)
+          ? null
+          : { label: `${value.id} - ${displayFields.map(f => get(value, f, '')).join(' ')}`, value }
+      }
     />
   );
 }
@@ -50,12 +54,7 @@ SelectOne.propTypes = {
   components: PropTypes.object,
   isDisabled: PropTypes.bool.isRequired,
   isLoading: PropTypes.bool.isRequired,
-  mainField: PropTypes.shape({
-    name: PropTypes.string.isRequired,
-    schema: PropTypes.shape({
-      type: PropTypes.string.isRequired,
-    }).isRequired,
-  }).isRequired,
+  displayFields: PropTypes.array.isRequired,
   name: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
   onInputChange: PropTypes.func.isRequired,

--- a/packages/strapi-plugin-content-manager/admin/src/components/SelectWrapper/Option.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/SelectWrapper/Option.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import { get, has, isEmpty } from 'lodash';
 import { Flex, Text } from '@buffetjs/core';
 import { RelationDPState } from 'strapi-helper-plugin';
-import { getDisplayedValue, getTrad } from '../../utils';
+import { getTrad } from '../../utils';
 
 const TextGrow = styled(Text)`
   flex-grow: 2;
@@ -22,8 +22,8 @@ const Option = props => {
     : 'components.Select.publish-info-title';
   const title = formatMessage({ id: getTrad(titleLabelID) });
   const fontWeight = props.isFocused ? 'bold' : 'regular';
-  const mainField = get(props, ['selectProps', 'mainField'], {});
-  const value = getDisplayedValue(mainField.schema.type, props.label, mainField.name);
+  const displayFields = get(props, ['selectProps', 'displayFields'], []);
+  const value = displayFields.map(f => get(props.data.value, f, '')).join(' ');
 
   if (hasDraftAndPublish) {
     return (
@@ -64,12 +64,7 @@ Option.propTypes = {
   isFocused: PropTypes.bool.isRequired,
   selectProps: PropTypes.shape({
     hasDraftAndPublish: PropTypes.bool,
-    mainField: PropTypes.shape({
-      name: PropTypes.string.isRequired,
-      schema: PropTypes.shape({
-        type: PropTypes.string.isRequired,
-      }).isRequired,
-    }).isRequired,
+    displayFields: PropTypes.array,
   }).isRequired,
 };
 

--- a/packages/strapi-plugin-content-manager/admin/src/components/SelectWrapper/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/SelectWrapper/index.js
@@ -21,6 +21,7 @@ import IndicatorSeparator from './IndicatorSeparator';
 import Option from './Option';
 import { A, BaselineAlignment } from './components';
 import { connect, select, styles } from './utils';
+import getRelationLabel from '../../utils/getRelationLabel';
 
 const initialPaginationState = {
   _contains: '',
@@ -51,7 +52,7 @@ function SelectWrapper({
   isCreatingEntry,
   isFieldAllowed,
   isFieldReadable,
-  mainField,
+  displayFields,
   name,
   relationType,
   targetModel,
@@ -149,7 +150,8 @@ function SelectWrapper({
         });
 
         const formattedData = data.map(obj => {
-          return { value: obj, label: obj[mainField.name] };
+          const label = `${obj.id} - ${getRelationLabel(displayFields, obj)}`;
+          return { value: obj, label };
         });
 
         setOptions(prevState =>
@@ -177,7 +179,7 @@ function SelectWrapper({
       containsKey,
       endPoint,
       idsToOmit,
-      mainField.name,
+      displayFields.join(','),
     ]
   );
 
@@ -318,7 +320,7 @@ function SelectWrapper({
           isDisabled={isDisabled}
           isLoading={isLoading}
           isClearable
-          mainField={mainField}
+          mainField={{ name: displayFields[0] }}
           move={moveRelation}
           name={name}
           options={filteredOptions}
@@ -353,6 +355,7 @@ SelectWrapper.defaultProps = {
   labelIcon: null,
   isFieldAllowed: true,
   placeholder: '',
+  displayFields: ['id'],
 };
 
 SelectWrapper.propTypes = {
@@ -369,12 +372,7 @@ SelectWrapper.propTypes = {
   isCreatingEntry: PropTypes.bool.isRequired,
   isFieldAllowed: PropTypes.bool,
   isFieldReadable: PropTypes.bool.isRequired,
-  mainField: PropTypes.shape({
-    name: PropTypes.string.isRequired,
-    schema: PropTypes.shape({
-      type: PropTypes.string.isRequired,
-    }).isRequired,
-  }).isRequired,
+  displayFields: PropTypes.array.isRequired,
   name: PropTypes.string.isRequired,
   placeholder: PropTypes.string,
   relationType: PropTypes.string.isRequired,

--- a/packages/strapi-plugin-content-manager/admin/src/components/SettingsViewWrapper/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/SettingsViewWrapper/index.js
@@ -4,6 +4,7 @@ import { get, isEqual, upperFirst } from 'lodash';
 import { withRouter } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
 import { Inputs as Input, Header } from '@buffetjs/custom';
+import MultiSelect from '../MultiSelect';
 import {
   BackHeader,
   LoadingIndicatorPage,
@@ -104,7 +105,7 @@ const SettingsViewWrapper = ({
       ];
     }
 
-    if (input.name === 'settings.mainField') {
+    if (input.name === 'settings.displayFields') {
       const options = Object.keys(attributes).filter(attr => {
         const type = get(attributes, [attr, 'type'], '');
 
@@ -162,23 +163,32 @@ const SettingsViewWrapper = ({
               <SectionTitle isSettings />
               <div className="row">
                 {inputs.map(input => {
+                  const isMulti = input.type === 'multi-select';
                   return (
                     <FormattedMessage key={input.name} id={input.label.id}>
                       {label => (
                         <div className={input.customBootstrapClass}>
-                          <FormattedMessage
-                            id={get(input, 'description.id', 'app.utils.defaultMessage')}
-                          >
-                            {description => (
-                              <Input
-                                {...input}
-                                description={description}
-                                label={label === ' ' ? null : label}
-                                onChange={onChange}
-                                options={getSelectOptions(input)}
-                                value={get(modifiedData, input.name, '')}
-                              />
-                            )}
+                          <FormattedMessage id={get(input, 'description.id', 'app.utils.defaultMessage')}>
+                            {description =>
+                              isMulti ? (
+                                <MultiSelect
+                                  name={input.name}
+                                  options={getSelectOptions(input)}
+                                  onChange={onChange}
+                                  value={get(modifiedData, input.name, [])}
+                                  placeholder={description}
+                                />
+                              ) : (
+                                <Input
+                                  {...input}
+                                  description={description}
+                                  label={label === ' ' ? null : label}
+                                  onChange={onChange}
+                                  options={getSelectOptions(input)}
+                                  value={get(modifiedData, input.name, '')}
+                                />
+                              )
+                            }
                           </FormattedMessage>
                         </div>
                       )}

--- a/packages/strapi-plugin-content-manager/admin/src/containers/EditSettingsView/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/containers/EditSettingsView/index.js
@@ -269,8 +269,8 @@ const EditSettingsView = ({ components, mainLayout, isContentTypeView, slug, upd
             description: {
               id: `${pluginId}.containers.SettingPage.editSettings.entry.title.description`,
             },
-            type: 'select',
-            name: 'settings.mainField',
+            type: 'multi-select',
+            name: 'settings.displayFields',
             customBootstrapClass: 'col-md-4',
             selectOptions: ['id'],
             didCheckErrors: false,

--- a/packages/strapi-plugin-content-manager/admin/src/containers/EditSettingsView/init.js
+++ b/packages/strapi-plugin-content-manager/admin/src/containers/EditSettingsView/init.js
@@ -7,6 +7,10 @@ const init = (initialState, mainLayout, components) => {
 
   set(initialData, ['layouts', 'edit'], formatLayout(createLayout(mainLayout.layouts.edit)));
 
+  if (!initialData.settings.displayFields) {
+    initialData.settings.displayFields = [initialData.settings.mainField];
+  }
+
   return fromJS({
     ...initialState.toJS(),
     initialData,

--- a/packages/strapi-plugin-content-manager/admin/src/utils/getRelationLabel.js
+++ b/packages/strapi-plugin-content-manager/admin/src/utils/getRelationLabel.js
@@ -1,0 +1,13 @@
+import get from 'lodash/get';
+
+const getRelationLabel = (displayFields, item) => {
+  if (!Array.isArray(displayFields)) {
+    displayFields = [displayFields];
+  }
+  return displayFields
+    .map(field => get(item, field, ''))
+    .filter(v => v !== '')
+    .join(' ');
+};
+
+export default getRelationLabel;

--- a/packages/strapi-plugin-content-manager/controllers/collection-types.js
+++ b/packages/strapi-plugin-content-manager/controllers/collection-types.js
@@ -273,10 +273,12 @@ module.exports = {
 
     const config = await contentTypeService.findConfiguration({ uid: model });
     const mainField = prop(['metadatas', assoc.alias, 'edit', 'mainField'], config);
+    const displayFields =
+      prop(['metadatas', assoc.alias, 'edit', 'displayFields'], config) || [mainField];
 
     ctx.body = {
       pagination: relationList.pagination,
-      results: relationList.results.map(pick(['id', modelDef.primaryKey, mainField])),
+      results: relationList.results.map(pick(['id', modelDef.primaryKey, ...displayFields])),
     };
   },
 };

--- a/packages/strapi-plugin-content-manager/services/utils/configuration/settings.js
+++ b/packages/strapi-plugin-content-manager/services/utils/configuration/settings.js
@@ -9,6 +9,7 @@ const DEFAULT_SETTINGS = {
   filterable: true,
   searchable: true,
   pageSize: 10,
+  displayFields: [],
 };
 
 const settingsFields = [
@@ -17,6 +18,7 @@ const settingsFields = [
   'bulkable',
   'pageSize',
   'mainField',
+  'displayFields',
   'defaultSortBy',
   'defaultSortOrder',
 ];
@@ -30,6 +32,7 @@ module.exports = {
     return {
       ...DEFAULT_SETTINGS,
       mainField: defaultField,
+      displayFields: [defaultField],
       defaultSortBy: defaultField,
       defaultSortOrder: 'ASC',
       ...getModelSettings(schema),
@@ -41,11 +44,16 @@ module.exports = {
 
     const defaultField = getDefaultMainField(schema);
 
-    const { mainField = defaultField, defaultSortBy = defaultField } = configuration.settings || {};
+    const {
+      mainField = defaultField,
+      displayFields = [mainField || defaultField],
+      defaultSortBy = defaultField,
+    } = configuration.settings || {};
 
     return {
       ...configuration.settings,
       mainField: isSortable(schema, mainField) ? mainField : defaultField,
+      displayFields: Array.isArray(displayFields) && displayFields.length > 0 ? displayFields : [mainField],
       defaultSortBy: isSortable(schema, defaultSortBy) ? defaultSortBy : defaultField,
     };
   },


### PR DESCRIPTION
## Summary
- show IDs when listing relation options or values in the admin panel
- keep selected field text after the id
- allow selecting multiple display fields

## Testing
- `npm run lint` *(fails: npm-run-all not found)*